### PR TITLE
Revert "chore(deps-dev): bump @types/sharp from 0.29.1 to 0.29.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@types/sharp": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.29.2.tgz",
-      "integrity": "sha512-tIbMvtPa8kMyFMKNhpsPT1HO3CgXLuiCAA8bxHAGAZLyALpYvYc4hUu3pu0+3oExQA5LwvHrWp+OilgXCYVQgg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.29.1.tgz",
+      "integrity": "sha512-UOQu+7MY/TRlVNjVuNtLpAlekKWNZNZzYtIDHRzPloKRkPW8jlPh1RsUIhyG98OibzzneqoAhb31C5j42ERFwA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/mime-types": "^2.1.0",
     "@types/node": "^16.9.1",
     "@types/puppeteer": "^5.4.0",
-    "@types/sharp": "^0.29.2",
+    "@types/sharp": "^0.29.1",
     "@types/ws": "^7.4.6",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.0",


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

-
-

To test (it takes a while): `npm install github:<username>/venom#<branch>`
